### PR TITLE
Fix build failure due to absolute JDK path

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,11 +8,9 @@
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
-# This option should only be used with decoupled projects. For more details, visit
-# https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects
+# This option should only be used with decoupled projects. For more details, visit https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects
 # org.gradle.parallel=true
-# AndroidX package structure to make it clearer which packages are bundled with the
-# Android operating system, and which are packaged with your app's APK
+# AndroidX package structure to clarify which packages are bundled with the Android OS and which are packaged with your app
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
@@ -23,5 +21,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 # Set Java 17 for Android Gradle Plugin
-org.gradle.java.home=C:\\Program Files\\Java\\jdk-17
+# Use JAVA_HOME from environment if available; otherwise rely on Gradle defaults
 


### PR DESCRIPTION
## Summary
- fix Gradle build failure by removing hardcoded Windows JDK path
- cleanup Gradle properties comments

## Testing
- `./gradlew ktlintCheck --no-daemon`
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841832571a883308e636ea4efc11bde